### PR TITLE
Superlint set editorconfig to false

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -29,3 +29,4 @@ jobs:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IGNORE_GITIGNORED_FILES: true
+          VALIDATE_EDITORCONFIG: false


### PR DESCRIPTION
Issue where superlinter was checking python-package.yml twice, once as expected and once as editor config